### PR TITLE
Strip subtotal/total footer lines from receipt line items.

### DIFF
--- a/lib/receipt-extract.ts
+++ b/lib/receipt-extract.ts
@@ -18,9 +18,9 @@ line_items (array of {
 
 Rules:
 - Use null for unknowns. Normalize numbers to decimals (no currency symbols).
-- Always fill totals.subtotal and totals.total when the receipt shows them. When the receipt shows subtotal and total but no separate tax line, set totals.tax to (total minus subtotal), rounded to two decimals — that difference is usually sales tax (HST/GST/PST) before tips or fees. If there is an explicit HST/GST line, use that amount for totals.tax instead.
+- Put receipt-level subtotal, tax, and total in totals (subtotal, tax, total) — do NOT add separate line_items for "Subtotal", "Total", or "Grand Total" footer rows; those double-count in expense totals. Only line_items should be actual purchases, discounts, and explicit tax lines (HST/GST/PST) when shown as their own line.
+- Always fill totals.subtotal and totals.total when the receipt shows them. When subtotal and total are present but no separate tax line, set totals.tax to (total minus subtotal), rounded to two decimals — that difference is usually sales tax (HST/GST/PST) before tips or fees. If there is an explicit HST/GST line, use that amount for totals.tax instead.
 - Canadian receipts: capture HST, GST, PST, QST, TPS/TVQ as shown. If tax appears per line, set hst on that line. If tax is only shown once at the bottom, set totals.tax to that amount.
-- Include non-product lines such as "Subtotal" and "Total" in line_items when they appear on the receipt (with their dollar amounts in total_price).
 - Loyalty / rewards: capture PC Optimum, Scene+, Air Miles, "points redeemed", "You saved", instant savings, and similar as line items when there is a dollar amount. Put savings in discount (positive dollars saved) or reflect in that line's total_price. Name the line clearly (e.g. "PC Optimum points redeemed", "Store promotion").
 - Harmonized Sales Tax: when the receipt shows a single tax line (e.g. "HST", "GST", "Tax"), include it as its own line_item with description mentioning tax and amounts in total_price and hst when possible.
 
@@ -135,38 +135,71 @@ function resolveTaxAmount(
 }
 
 /**
+ * Footer rows that are not real purchases — they inflate dashboard sums if left in line_items.
+ * Does not remove explicit HST/GST/PST tax lines.
+ */
+function isSummaryFooterLine(li: LineItemExtract): boolean {
+  const raw = li.description.trim()
+  const d = raw.replace(/\s+/g, ' ')
+  const lower = d.toLowerCase()
+
+  // Synthetic line added by enrichReceiptExtract
+  if (lower.includes('subtotal vs total')) return false
+
+  if (/^(hst|gst|pst|qst)(\s|$|[:(])/i.test(d)) return false
+  if (/^sales tax\b/i.test(d)) return false
+  if (/^harmonized\b/i.test(lower)) return false
+  if (/\btax\b/i.test(d) && /hst|gst|pst|qst|sales|harmonized/i.test(lower)) return false
+
+  if (/^subtotal\b/i.test(d) || /^sub-total\b/i.test(d) || /^sub total\b/i.test(d)) return true
+  if (/^grand\s*total\b/i.test(lower)) return true
+  if (/^amount\s*due\b/i.test(lower)) return true
+  if (/^balance\s*due\b/i.test(lower) || /^balance$/i.test(lower)) return true
+  if (/^total\s*due\b/i.test(lower)) return true
+  if (/^total$/i.test(d.trim())) return true
+  if (/^total\s*:/i.test(d)) return true
+
+  return false
+}
+
+function stripSummaryFooterLines(lines: LineItemExtract[]): LineItemExtract[] {
+  return lines.filter((li) => !isSummaryFooterLine(li))
+}
+
+/**
  * If we can determine tax but no line carries it, add one synthetic tax line so clients can show HST.
  */
 export function enrichReceiptExtract(receipt: ReceiptExtract): ReceiptExtract {
   const lines = [...(receipt.line_items ?? [])]
+  let mergedTotals: NonNullable<ReceiptExtract['totals']> = { ...(receipt.totals ?? {}) }
 
   const resolved = resolveTaxAmount(receipt.totals, lines)
-  if (resolved == null) {
-    return { ...receipt, line_items: lines }
+  if (resolved != null) {
+    mergedTotals = resolved.mergedTotals
+    const { tax: taxAmount } = resolved
+
+    const taxLabel = /\b(HST|GST|PST|QST|TPS|TVQ|harmonized|sales tax|Harmonized)\b/i
+    const hasDedicatedTaxLine = lines.some(
+      (li) =>
+        taxLabel.test(li.description) ||
+        (li.category != null && /^tax$/i.test(String(li.category).trim()))
+    )
+    const hasMeaningfulLineHst = lines.some((li) => (li.hst ?? 0) > 0.005)
+
+    if (!hasDedicatedTaxLine && !hasMeaningfulLineHst) {
+      const t = round2(taxAmount)
+      lines.push({
+        description: 'Sales tax (HST/GST/PST — subtotal vs total)',
+        category: 'Tax',
+        quantity: null,
+        unit_price: null,
+        total_price: t,
+        hst: t,
+        discount: null,
+      })
+    }
   }
 
-  const { tax: taxAmount, mergedTotals } = resolved
-
-  const taxLabel = /\b(HST|GST|PST|QST|TPS|TVQ|harmonized|sales tax|Harmonized)\b/i
-  const hasDedicatedTaxLine = lines.some(
-    (li) =>
-      taxLabel.test(li.description) ||
-      (li.category != null && /^tax$/i.test(String(li.category).trim()))
-  )
-  const hasMeaningfulLineHst = lines.some((li) => (li.hst ?? 0) > 0.005)
-
-  if (!hasDedicatedTaxLine && !hasMeaningfulLineHst) {
-    const t = round2(taxAmount)
-    lines.push({
-      description: 'Sales tax (HST/GST/PST — subtotal vs total)',
-      category: 'Tax',
-      quantity: null,
-      unit_price: null,
-      total_price: t,
-      hst: t,
-      discount: null,
-    })
-  }
-
-  return { ...receipt, totals: mergedTotals, line_items: lines }
+  const stripped = stripSummaryFooterLines(lines)
+  return { ...receipt, totals: mergedTotals, line_items: stripped }
 }


### PR DESCRIPTION
Remove summary rows from line_items after tax inference so dashboards do not sum them; keep HST/GST lines and the synthetic tax line. Prompt tells the model not to emit subtotal/total as line items.